### PR TITLE
user dbid fixes on non targets api, availability fixes, cannot call self

### DIFF
--- a/src/service/controllers/media.js
+++ b/src/service/controllers/media.js
@@ -52,12 +52,14 @@ exports.initializeMediaData = (user) => {
     return {
       channels: [{
         name: 'email',
+        available: false,
         state: 'NotReady',
         dnd: false,
         reasons: [],
         timestamp: Date.now()
       }, {
         name: 'workitem',
+        available: false,
         state: 'NotReady',
         dnd: false,
         reasons: [],
@@ -296,9 +298,10 @@ exports.handleWorkitemInteraction = (req, res, interaction) => {
   }
 }
 
-changeMediState = (req, media, state, options) => {
+changeMediaState = (req, media, state, options) => {
   if (media) {
     media.state = state;
+    media.available = (state === 'Ready');
     if (options) {
       media.dnd = options.dnd;
       if (options.reasonCode) {
@@ -326,10 +329,10 @@ exports.changeState = (req, state, options) => {
       const mediaName = req && req.params ? req.params.media : (options ? options.media : null);
       if (mediaName) {
         const media = _.find(user.activeSession.media.channels, function (m) { return m.name === mediaName; });
-        changeMediState(req, media, state, options);
+        changeMediaState(req, media, state, options);
       } else {
         _.each(user.activeSession.media.channels, (m) => {
-          changeMediState(req, m, state, options);
+          changeMediaState(req, m, state, options);
         });
       }
     }

--- a/src/service/routes/voice.js
+++ b/src/service/routes/voice.js
@@ -68,6 +68,12 @@ router.use('/workspace/v3/voice/make-call', (req, res) => {
   const userName = auth.userByCode(req);
   // get dest user
   const destUser = conf.userByDestination(req.body.data.destination);
+  // Cannot call self
+  if (userName === destUser.userName) {
+    res.send(defaultResponse());
+    voice.sendInvalidDN(userName);
+    return;
+  }
   let call;
   if (destUser) {
     // create an internal call


### PR DESCRIPTION
This PR should fix multiples issues, see the list here:

- On non /targets api, the user dbid value can be found with the user.dbid attribute, but the simulator has only user.DBID, both are set to support multiple API endpoints with only one set of objects.
- The agents states should now be working properly, earlier, the avaibility was set to LoggedOff is the agent was not logged in, otherwise he was "Ready". It should now support "Ready", "Partial Ready", "Not Ready" and "Logged Off".
- The agent cannot call itself (the action button is now hidden), and if he calls via his number, it send an Invalid DN error, like in normal environments.