### PR TITLE
Feat/transfer-conference/GAPI-30583: Support of transfer and conference use cases

### DIFF
--- a/src/service/controllers/media.js
+++ b/src/service/controllers/media.js
@@ -174,7 +174,9 @@ exports.handleInteraction = (req, res) => {
     interaction.state = "Processing";
     addInteractionForAgent(req.body.data.agentId, interaction);
     exports.publishInteractionEvent(req.body.data.agentId, 'email', interaction)
-  } 
+  } else if (req.params.media === 'email') { 
+    exports.handleEmailInteraction(req, res, interaction)
+  }
   else {
     utils.sendFailureStatus(res, 501);
   }

--- a/src/service/controllers/media.js
+++ b/src/service/controllers/media.js
@@ -162,9 +162,20 @@ exports.handleInteraction = (req, res) => {
     exports.handleOutboundPreviewInteraction(req, res, interaction);
   } else if (req.params.fn === 'add-attachment') {
     exports.handleAttachments(req, res);
-  } else if(req.params.media === 'email'){ 
-    exports.handleEmailInteraction(req, res, interaction)
-  } else {
+  } else if(req.params.fn === "transfer-agent"){
+    let originAgent = "";
+    for(dataObject of interaction.userData){
+      if(dataObject.key === "IW_RoutingBasedOriginalEmployeeId"){
+        originAgent = dataObject.value;
+      }
+    }
+    interaction.state = "Completed";
+    exports.publishInteractionEvent(originAgent, 'email', interaction)
+    interaction.state = "Processing";
+    addInteractionForAgent(req.body.data.agentId, interaction);
+    exports.publishInteractionEvent(req.body.data.agentId, 'email', interaction)
+  } 
+  else {
     utils.sendFailureStatus(res, 501);
   }
 }

--- a/src/service/controllers/ucs.js
+++ b/src/service/controllers/ucs.js
@@ -105,6 +105,13 @@ exports.handleInteractionSetComment = (req, res) => {
 	});
 }
 
+exports.getContact = (id = 0) => {
+	const matchingContact = _.find(contacts, (contact) => {
+		return contact.id === id;
+	});
+	return matchingContact || false;
+}
+
 getLuceneIndexes = (req, res) => {
 	utils.sendOkStatus(req, res);
 	this.publishUcsEvent(req, 'EventGetIndexProperties', { indexes: luceneIndexes });

--- a/src/service/controllers/voice.js
+++ b/src/service/controllers/voice.js
@@ -11,6 +11,9 @@ const messaging = require("./messaging");
 const rmm = require("../common/rmm");
 const reporting = require("./reporting");
 const utils = require("../common/utils");
+const { isUndefined, object } = require("underscore");
+const { handleInteractionDeleteUserdata } = require("./media");
+const ucs = require("../controllers/ucs");
 
 var attachedData = utils.requireAndMonitor(
   "../../../data/media/attached-data.yaml",
@@ -206,6 +209,17 @@ exports.handleCall = (req, res) => {
     utils.sendFailureStatus(res, 500, msg);
     return;
   }
+  let originContact;
+  let participantAdded = {}
+  if (req.params.fn === 'single-step-conference' || req.params.fn === 'complete-conference') {
+      originContact = ucs.getContact(call.userData[6]?.value) || (ucs.getContact(calls[call.originCall.parentConnId].userData[6].value));
+    if (call.originCall.parentConnId) {
+      calls[call.originCall.parentConnId].isConference = true;
+    }
+    else {
+      call.isConference = true;
+    }
+  }
   switch (req.params.fn) {
   case "answer":
   	if (!checkIfCallMonitored(req, res, call, user, 'Established')) {
@@ -252,46 +266,108 @@ exports.handleCall = (req, res) => {
     break;
   case "single-step-conference":
     call.state = "Established";
-
-    var participantAdded = {};
+    const newAgent = conf.userByDestination(req.body.data.destination);
+    call.callByUserName[newAgent.userName] = call.callByUserName[call.destUser.userName];
     if (destUser) {
       participantAdded.number = destUser.activeSession.dn.number;
     } else {
       participantAdded.number = req.body.data.destination;
     }
     participantAdded.role = "RoleNewParty";
-    call.onEstablished(participantAdded);
-
-    reportCallState(call);
-    utils.sendOkStatus(req, res);
-    exports.publishCallEvent(call, userName);
+    call.onEstablished(participantAdded, req.params.fn);   
+    call.originCall.participants[0].number = originContact.phoneNumbers[0];
+    call.destCall.participants[0].number = originContact.phoneNumbers[0];
+    exports.publishAgentCallEvent(newAgent.userName, call.originCall)
     break;
   case "single-step-transfer":
-    /**
-     * Not actually transferring a call. For now just complete the call so that
-     * it appears to be transferred from this agent's perspective.
-     */
+    const newDestination = conf.userByDestination(req.body.data.destination);
+    const newDestUserName = newDestination ? newDestination.userName : null;
+    call.callByUserName[newDestUserName] = call.callByUserName[call.destUser.userName];
+    call.state = "Released";
+    exports.publishAgentCallEvent(call.destUser.userName, call.originCall);
+    call.destUser = newDestination;
+    call.destUserName = newDestUserName;
+    call.state = "Established";
+    transferedCalls[call.id] = {};
+    Object.assign(transferedCalls[call.id], agentCall);
+    exports.publishAgentCallEvent(newDestUserName, call.originCall);
+    break;
+  case "complete-transfer":
+    const parentCall = calls[call.originCall.parentConnId];
     call.state = "Completed";
-    reportCallState(call);
-    rmm.recordInteractionComplete(userName, agentCall.id);
-    utils.sendOkStatus(req, res);
-    exports.publishCallEvent(call, userName);
+    parentCall.state = "Released";
+    exports.publishAgentCallEvent(parentCall.destUser.userName, parentCall.originCall);
+    exports.publishCallEvent(call); 
+    parentCall.destUser = call.destUser;
+    parentCall.callByUserName[call.destUser.userName] = parentCall.callByUserName[parentCall.destUserName];
+    parentCall.destUserName = call.destUserName;
+    parentCall.state = "Established";
+    exports.publishAgentCallEvent(parentCall.destUserName,parentCall.originCall);
+    break; 
+  case "complete-conference":
+    const parent = calls[call.originCall.parentConnId];
+    call.state = "Completed";
+    exports.publishCallEvent(call);
+    participantAdded.number = call.originCall.participants[0].number;
+    participantAdded.role = "RoleNewParty";
+    parent.state = "Established";
+    parent.onEstablished(participantAdded, req.params.fn);
+    parent.originCall.participants[0].number = originContact.phoneNumbers[0];
+    parent.destCall.participants[0].number = originContact.phoneNumbers[0];
+    exports.publishAgentCallEvent(call.originUser.userName, parent.originCall);
+    parent.callByUserName[call.destUserName] = parent.callByUserName[parent.destUser.userName];
+    exports.publishAgentCallEvent(call.destUser.userName, parent.originCall);
+   break;
   case "release":
   	if (!checkIfCallMonitored(req, res, call, user, 'Released', [ 'complete' ])) {
       call.state = "Released";
       reportCallState(call);
       utils.sendOkStatus(req, res);
-      exports.publishCallEvent(call);
+      if (userName !== call.destUserName && Object.keys(call.callByUserName).length > 2) {
+        if (call.isConference) {
+          exports.publishAgentCallEvent(user.userName, call.originCall);
+          call.destCall.participants.splice(1,1);  
+          call.state = 'Established';
+          exports.publishAgentCallEvent(call.destUserName, call.destCall);
+          call.isConference = false;
+        }
+        else {
+          exports.publishAgentCallEvent(user.userName, call.originCall);
+          exports.publishAgentCallEvent(call.destUserName, call.destCall);
+        }
+      }
+      else {
+        if (call.isConference) {
+          const leftUserNumber = call.destCall.participants[1].number;
+          const leftUser = conf.userByDestination(leftUserNumber);
+          exports.publishAgentCallEvent(call.destUserName, call.destCall);
+          call.originCall.participants.splice(1,1);  
+          call.state = 'Established';
+          exports.publishAgentCallEvent(leftUser.userName, call.originCall);  
+          call.isConference = false;          
+        }
+        else {
+          exports.publishCallEvent(call);
+        }
+      }
+      
     }
     break;
   case "complete":
   	if (!checkIfCallMonitored(req, res, call, user, 'Completed')) {
-      agentCall.state = "Completed";
-      call.deleteCall();
-      reportCallStateForAgent(userName, agentCall);
-      rmm.recordInteractionComplete(userName, agentCall.id);
-      utils.sendOkStatus(req, res);
-      exports.publishAgentCallEvent(userName, agentCall, '', req.body ? req.body.operationId : '');
+      if (!agentCall && call.callByUserName.length != 0) {
+        agentCall = call.callByUserName[0];
+        agentCall.state = "Completed";
+        call.deleteCall(agentCall.userName);
+      }
+      else {
+        call.state = "Completed";
+        call.deleteCall();
+      }
+       exports.publishAgentCallEvent(userName, agentCall, '', req.body ? req.body.operationId : '');
+       reportCallStateForAgent(userName, agentCall);
+       rmm.recordInteractionComplete(userName, agentCall.id);
+       utils.sendOkStatus(req, res);
     }
     break;
   case "start-recording": case "resume-recording":
@@ -924,17 +1000,23 @@ class Call {
     dest.parentConnId = connId;
   }
 
-  addParticipant(participant) {
+  addParticipant(participant, callType) {
     var origin = this.originCall;
     var dest = this.destCall;
-    origin.participants.push(participant);
+    if(callType === 'single-step-conference' || callType === 'complete-conference'){
+      origin.participants.unshift(dest.participants[0]);
+    }
+    else{
+      origin.participants.push(participant);
+    }
+    
     dest.participants.push(participant);
   }
 
-  onEstablished(participant) {
+  onEstablished(participant, callType) {
   	checkIfParticipantsMonitored(this);
   	if (participant) {
-  		this.addParticipant(participant);
+  		this.addParticipant(participant, callType);
   	}
   }
 


### PR DESCRIPTION
Added next cases:
**Single-step email transfer:**
-   User needs to click  the "transfer" button and choose an agent to transfer email


**2. Two-step email transfer:**
-  User need to begin consultation with another agent
-  User need to repeat " email single-step transfer" actions

**3. Single-step call transfer:**

- When the agent gets the call, he can choose another agent to send this call

**4. Two-step call transfer:**

- The agent can send the call to another agent after starting parallel consultation

**5. Single-step call conference**
 
- The agent can add the new user to an existing call and transform it into a group conference

**6. Two-step call conference**

- The agent can add the new user to an existing call after consultation