### PR TITLE
WWE-772 [Agent Api Simulator] Issues with multi-tabs

### DIFF
--- a/src/service/controllers/messaging.js
+++ b/src/service/controllers/messaging.js
@@ -74,7 +74,6 @@ exports.getSessions = (req, res) => {
 	return _.keys(sessions);
 }
 
-
 exports.publish = (req, channel, msg) => {
 	var userName = _.isString(req) ? req : auth.userByCode(req);
 	var session = sessions[userName];
@@ -112,9 +111,7 @@ publish2 = (session, channel, msg) => {
 	if (session) {
 		session.deliver(null, channel, msg);
 	}
-	
 }
-
 
 publishWorkspaceInitializationProgress = (session, percentComplete, user, configuration) => {
 	var msg = {


### PR DESCRIPTION
Reason:
The issue was caused because of the algorithm which works when the user creates new tab. When user run new tab, the program creates new session and switch it with the cometd session already existed and the server-side events were published to the last opened tab.
Solution:
Instead of single session for last opened tab API simulator will use an array with the all opened tabs sessions. When the user creates new tab, sessions of the old tabs will be saved and will continue to recieve published events.