### PR TITLE
Fix dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,11 +7,10 @@ WORKDIR /app/agent-api-simulator
 COPY . .
 
 # Install dependencies
-
 RUN npm install
+RUN npm run install
 
 # Build
-
 RUN npm run build
 
 # Expose the ports

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Install dependencies:
 
 ```shell
 npm install
+npm run install
 ```
 
 Build the front end:


### PR DESCRIPTION
The dependencies for the sub-projects are missing, and therefore the build will fail. To fetch these additional dependencies we have to run the predefined install script from the package.json. 

This solves build problems with the Docker image to.