### PR TITLE
[Agent-Api-Simulator] The Interaction Bar shows wrong party member after agent transfers an internal call

### DIFF
--- a/src/service/controllers/voice.js
+++ b/src/service/controllers/voice.js
@@ -288,12 +288,16 @@ exports.handleCall = (req, res) => {
     exports.publishCallEvent(call, userName);
     call.callByUserName[newDestUserName] = call.callByUserName[call.destUser.userName];
     call.state = "Released";
-    exports.publishAgentCallEvent(call.destUser.userName, call.originCall);
+    exports.publishAgentCallEvent(call.destUser.userName, call.destCall);
+    exports.publishAgentCallEvent(call.originUser.userName, call.originCall);
     call.destUser = newDestination;
     call.destUserName = newDestUserName;
     call.state = "Ringing";
     transferedCalls[call.id] = {};
     Object.assign(transferedCalls[call.id], agentCall);
+    call.originCall.dnis = newDestination.agentLogin;
+    call.originCall.participants[0].number = newDestination.agentLogin;
+
     exports.publishAgentCallEvent(newDestUserName, call.originCall);
     break;
   case "complete-transfer":


### PR DESCRIPTION


The reason for the problem was incorrect combinations of usernames and related calls. It also was no change of destination user during the transfer

Now it is correctly published call events with correct combinations of usernames and calls. It also adds a number of agents who gets the transfer to participants[0] where saved call destination