### PR TITLE
WWE-2063 [API Simulator] Outbound call created from API-simulator UI can not be transfered

### DIFF
--- a/src/service/controllers/voice.js
+++ b/src/service/controllers/voice.js
@@ -293,7 +293,9 @@ exports.handleCall = (req, res) => {
     call.callByUserName[newDestUserName] = call.callByUserName[call.destUser.userName];
     call.state = "Released";
     exports.publishAgentCallEvent(call.destUser.userName, call.destCall);
-    exports.publishAgentCallEvent(call.originUser.userName, call.originCall);
+    if(call.originUser && call.originUser.userName) {
+      exports.publishAgentCallEvent(call.originUser.userName, call.originCall);
+    }
     call.destUser = newDestination;
     call.destUserName = newDestUserName;
     call.state = "Ringing";


### PR DESCRIPTION
There was a problem that during the call from API Simulator UI the field 'originUser' in the call object is no exists. So there was added a new check to avoid the exception.